### PR TITLE
CloudGenerator: create changes directory in /db/

### DIFF
--- a/source/src/main/java/CloudGenerator.java
+++ b/source/src/main/java/CloudGenerator.java
@@ -365,6 +365,7 @@ public class CloudGenerator {
     private static void fetchAllGerritCommits() throws Exception {
         final StringBuffer start = new StringBuffer("2010-10-28");
         File statsDir = new File(CHANGES_DIR);
+        statsDir.mkdirs();
         FileUtils.listFiles(statsDir, new IOFileFilter() {
             @Override
             public boolean accept(File dir, String name) {


### PR DESCRIPTION
Fixes: Exception in thread "main" java.lang.IllegalArgumentException: Parameter 'directory' is not a directory.

Fixes #2
